### PR TITLE
Add System.Core reference

### DIFF
--- a/Build/Projects/Jitter.definition
+++ b/Build/Projects/Jitter.definition
@@ -2,6 +2,7 @@
 <Project Name="Jitter" Path="Jitter" Type="Library">
   <References>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
   </References>
   <Files>
     <Compile Include="Collision\CollisionIsland.cs" />


### PR DESCRIPTION
Fix the build on Mac by adding a System.Core reference.
